### PR TITLE
feat: use new model and updated docker components

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,7 @@ README.md
 
 # Exclude Terraform directories for now
 terraform
+infra
 
 # Exclude Ollama directories
 ollama/

--- a/Modelfile
+++ b/Modelfile
@@ -1,7 +1,10 @@
-FROM gemma3:1b
+FROM gemma3:1b-it-qat
 
 # set the temperature to 1 [higher is more creative, lower is more coherent]
 PARAMETER temperature 0
+
+# set a lower context
+PARAMETER num_ctx 2048
 
 # set the system message
 SYSTEM """

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,6 +1,5 @@
 services:
   web:
-    # Build the image from the Dockerfile in the current directory
     build:
       context: .
       args:
@@ -11,10 +10,8 @@ services:
       - OLLAMA_HOST=ollama:11434
     depends_on:
       - ollama
-    # Host the Flask application on port 8080
     ports:
       - "8080:8080"
-
     develop:
       # Create a `watch` configuration to update the app
       # https://docs.docker.com/compose/file-watch/#compose-watch-versus-bind-mounts
@@ -27,7 +24,6 @@ services:
           # different platform in the container
           ignore:
             - .venv/
-
         # Rebuild the image if dependencies change by checking uv.lock
         - action: rebuild
           path: ./uv.lock
@@ -35,24 +31,24 @@ services:
       - ollama-docker
 
   ollama:
-    # Use the official Ollama image
-    image: ollama/ollama:latest
+    build:
+      context: .
+      dockerfile: ollama.Dockerfile
     environment:
       - OLLAMA_HOST=0.0.0.0:11434
-    # Expose the Ollama API on port 11434
+      - OLLAMA_MAX_LOADED_MODELS=1
+      - OLLAMA_NUM_PARALLEL=1
+      - OLLAMA_MAX_QUEUE=10
     ports:
       - "11434:11434"
-
     volumes:
       - ./ollama/ollama:/root/.ollama
       - ./entrypoint.sh:/entrypoint.sh
       - ./Modelfile:/root/Modelfile
-
     entrypoint: ["/usr/bin/bash", "./entrypoint.sh"]
     networks:
       - ollama-docker
 
 networks:
   ollama-docker:
-    # Use the default bridge network
     driver: bridge

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,12 +10,12 @@ sleep 5
 
 # Create custom model.
 echo "🔵 Creating custom model..."
-ollama create marcos-assistant:1.0 -f /root/Modelfile
+ollama create marcos-assistant:2.0 -f /root/Modelfile
 echo "🟢 Done!"
 
 # Run the custom model.
 echo "🔵 Running custom model..."
-ollama run marcos-assistant:1.0
+ollama run marcos-assistant:2.0
 echo "🟢 Done!"
 
 # echo "🔴 Retrieve DeepSeek model..."

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ def chat_stream():
 
     def generate():
         stream = chat(
-            model="marcos-assistant:1.0",
+            model="marcos-assistant:2.0",
             messages=[{"role": "user", "content": prompt}],
             stream=True,
         )

--- a/ollama.Dockerfile
+++ b/ollama.Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # Dockerfile for custom Ollama container
 FROM ollama/ollama:latest
 

--- a/ollama.Dockerfile
+++ b/ollama.Dockerfile
@@ -3,8 +3,11 @@
 # Dockerfile for custom Ollama container
 FROM ollama/ollama:latest
 
-# Set environment variable for Ollama host
+# Set environment variable for Ollama
 ENV OLLAMA_HOST=0.0.0.0:11434
+ENV  OLLAMA_MAX_LOADED_MODELS=1
+ENV OLLAMA_NUM_PARALLEL=1
+ENV OLLAMA_MAX_QUEUE=10
 
 # Copy custom model and entrypoint script into the container
 # COPY ollama/ollama /root/.ollama

--- a/ollama.Dockerfile.dockerignore
+++ b/ollama.Dockerfile.dockerignore
@@ -37,6 +37,7 @@ README.md
 
 # Exclude Terraform directories for now
 terraform
+infra
 
 # Exclude Application code
 .python-version


### PR DESCRIPTION
This PR adds:

- usage of a more optimal model `gemma3:1b-it-qat` (Quantization aware trained models (QAT) that uses less memory and performs almost the same.
- ollama env vars and parameters (context is now 2048 instea of 4096) to improve performance.
- a few updates in the Dockerfiles and compose.
- ignoring infra directory in dockerignores.

Fixes #11 