### PR TITLE
feat: use gemma3:270m model

### DIFF
--- a/Modelfile
+++ b/Modelfile
@@ -1,4 +1,4 @@
-FROM gemma3:1b-it-qat
+FROM gemma3:270m
 
 # set the temperature to 1 [higher is more creative, lower is more coherent]
 PARAMETER temperature 0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Built with Python, Flask, and Ollama AI models.
 ---
 
 ## Features
-- Interactive AI assistant powered by Ollama (Gemma model)
+- Interactive AI assistant powered by Ollama (Gemma gemma3:270m model)
 - Custom dropdown with predefined questions
 - Real-time streaming responses (SSE)
 - Responsive, modern UI
@@ -89,7 +89,7 @@ See the `config/` directory for deployment configuration files.
 
 ## Technologies Used
 - [Flask](https://flask.palletsprojects.com/) - Web framework
-- [Ollama](https://ollama.ai/) - AI model server (Gemma 1B)
+- [Ollama](https://ollama.ai/) - AI model server (Gemma gemma3:270m)
 - [Docker](https://www.docker.com/) & [Docker Compose](https://docs.docker.com/compose/)
 - [Gunicorn](https://gunicorn.org/) - Production WSGI server
 - [uv](https://github.com/astral-sh/uv) - Fast Python package manager


### PR DESCRIPTION
This change updates the default model that the app uses,
for a smaller one with better performance, [gemma3:270m](https://ollama.com/library/gemma3:270m).